### PR TITLE
Update to .NET 8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 5.x
+          dotnet-version: 8.x
       - name: Restore
         run: dotnet restore src/Giraffe.Website/Giraffe.Website.fsproj
       - name: Build

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,12 @@
 Release Notes
 =============
 
+## 1.6.0
+
+- Replace `master` branch by `main` for Giraffe documentation
+- CI version updates
+- Update project to .NET 8 (F# code and Dockerfile)
+
 ## 1.5.0
 
 CSS changes.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,9 +3,9 @@ Release Notes
 
 ## 1.6.0
 
-- Replace `master` branch by `main` for Giraffe documentation
-- CI version updates
-- Update project to .NET 8 (F# code and Dockerfile)
+- [Minor CSS change](https://github.com/giraffe-fsharp/giraffe-website/pull/3) - Credits @m-rinaldi
+- [(CI) GitHub actions version update](https://github.com/giraffe-fsharp/giraffe-website/pull/5) - Credits @64J0
+- [Update to .NET 8](https://github.com/giraffe-fsharp/giraffe-website/pull/2) - Credits @64J0
 
 ## 1.5.0
 

--- a/src/Giraffe.Website/Common.fs
+++ b/src/Giraffe.Website/Common.fs
@@ -216,7 +216,7 @@ module NetworkExtensions =
     type IApplicationBuilder with
         member this.UseTrailingSlashRedirection() =
             this.Use(
-                fun ctx next ->
+                fun (ctx: HttpContext) (next: RequestDelegate) ->
                     let hasTrailingSlash =
                         ctx.Request.Path.HasValue
                         && ctx.Request.Path.Value.EndsWith "/"
@@ -229,13 +229,13 @@ module NetworkExtensions =
                         let url = Microsoft.AspNetCore.Http.Extensions.UriHelper.GetEncodedUrl ctx.Request
                         ctx.Response.Redirect(url, true)
                         Threading.Tasks.Task.CompletedTask
-                    | false -> next.Invoke())
+                    | false -> next.Invoke(ctx))
 
         member this.UseHttpsRedirection (isEnabled : bool, domainName : string) =
             match isEnabled with
             | true ->
                 this.Use(
-                    fun ctx next ->
+                    fun (ctx: HttpContext) (next: RequestDelegate) ->
                         let host = ctx.Request.Host.Host
                         // Only HTTPS redirect for the chosen domain:
                         let mustUseHttps =
@@ -246,7 +246,7 @@ module NetworkExtensions =
                         if not mustUseHttps then
                             ctx.Request.Scheme  <- "https"
                             ctx.Request.IsHttps <- true
-                        next.Invoke())
+                        next.Invoke(ctx))
                     .UseHttpsRedirection()
             | false -> this
 

--- a/src/Giraffe.Website/Dockerfile
+++ b/src/Giraffe.Website/Dockerfile
@@ -11,9 +11,9 @@ RUN dotnet publish /p:Version=$version Giraffe.Website/Giraffe.Website.fsproj -c
 # Build runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine AS runtime
 
-# This was a breaking change on .NET 8
+# Change the HTTP port that the server process is listening
 # https://learn.microsoft.com/en-us/dotnet/core/compatibility/containers/8.0/aspnet-port
-ENV ASPNETCORE_HTTP_PORTS=80
+ENV ASPNETCORE_HTTP_PORTS=5000
 
 WORKDIR /app
 COPY --from=build /app/published .

--- a/src/Giraffe.Website/Dockerfile
+++ b/src/Giraffe.Website/Dockerfile
@@ -11,6 +11,10 @@ RUN dotnet publish /p:Version=$version Giraffe.Website/Giraffe.Website.fsproj -c
 # Build runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine AS runtime
 
+# This was a breaking change on .NET 8
+# https://learn.microsoft.com/en-us/dotnet/core/compatibility/containers/8.0/aspnet-port
+ENV ASPNETCORE_HTTP_PORTS=80
+
 WORKDIR /app
 COPY --from=build /app/published .
 ENTRYPOINT ["dotnet", "Giraffe.Website.dll"]

--- a/src/Giraffe.Website/Dockerfile
+++ b/src/Giraffe.Website/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build
 
 ARG version=0.0.0-undefined
 
@@ -9,7 +9,7 @@ COPY src/ ./
 RUN dotnet publish /p:Version=$version Giraffe.Website/Giraffe.Website.fsproj -c Release -o published
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:5.0-alpine AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine AS runtime
 
 WORKDIR /app
 COPY --from=build /app/published .

--- a/src/Giraffe.Website/Giraffe.Website.fsproj
+++ b/src/Giraffe.Website/Giraffe.Website.fsproj
@@ -1,16 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
     <EnableDefaultContentItems>false</EnableDefaultContentItems>
     <RunWorkingDirectory>$(MSBuildThisFileDirectory)</RunWorkingDirectory>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Giraffe" Version="5.0.0" />
-    <PackageReference Include="Giraffe.ViewEngine" Version="1.3.*" />
-    <PackageReference Include="Ply" Version="0.3.*" />
+    <PackageReference Include="Giraffe" Version="6.4.0" />
+    <PackageReference Include="Giraffe.ViewEngine" Version="1.4.0" />
     <PackageReference Include="Logfella" Version="7.1.*" />
     <PackageReference Include="Sentry.AspNetCore" Version="2.1.*" />
     <PackageReference Include="Markdig" Version="0.22.*" />

--- a/src/Giraffe.Website/Program.fs
+++ b/src/Giraffe.Website/Program.fs
@@ -252,15 +252,15 @@ module WebApp =
 
     let linkReplacements =
         [
-            "https://github.com/giraffe-fsharp/Giraffe/blob/master/README.md", (Url.create "/")
-            "https://github.com/giraffe-fsharp/Giraffe/blob/master/DOCUMENTATION.md", (Url.create "/docs")
+            "https://github.com/giraffe-fsharp/Giraffe/blob/main/README.md", (Url.create "/")
+            "https://github.com/giraffe-fsharp/Giraffe/blob/main/DOCUMENTATION.md", (Url.create "/docs")
             "https://github.com/giraffe-fsharp/Giraffe.ViewEngine/blob/master/README.md", (Url.create "/view-engine")
         ] |> Map.ofList
 
     let private indexHandler =
         allowCaching (TimeSpan.FromDays(1.0)) >=>
         markdownHandler
-            "https://raw.githubusercontent.com/giraffe-fsharp/Giraffe/master/README.md"
+            "https://raw.githubusercontent.com/giraffe-fsharp/Giraffe/main/README.md"
             "Home"
             (Url.create "/")
             4
@@ -269,7 +269,7 @@ module WebApp =
     let private docsHandler =
         allowCaching (TimeSpan.FromDays(1.0)) >=>
         markdownHandler
-            "https://raw.githubusercontent.com/giraffe-fsharp/Giraffe/master/DOCUMENTATION.md"
+            "https://raw.githubusercontent.com/giraffe-fsharp/Giraffe/main/DOCUMENTATION.md"
             "Documentation"
             (Url.create "/docs")
             0

--- a/src/Giraffe.Website/Program.fs
+++ b/src/Giraffe.Website/Program.fs
@@ -251,15 +251,15 @@ module WebApp =
 
     let linkReplacements =
         [
-            "https://github.com/giraffe-fsharp/Giraffe/blob/main/README.md", (Url.create "/")
-            "https://github.com/giraffe-fsharp/Giraffe/blob/main/DOCUMENTATION.md", (Url.create "/docs")
+            "https://github.com/giraffe-fsharp/Giraffe/blob/master/README.md", (Url.create "/")
+            "https://github.com/giraffe-fsharp/Giraffe/blob/master/DOCUMENTATION.md", (Url.create "/docs")
             "https://github.com/giraffe-fsharp/Giraffe.ViewEngine/blob/master/README.md", (Url.create "/view-engine")
         ] |> Map.ofList
 
     let private indexHandler =
         allowCaching (TimeSpan.FromDays(1.0)) >=>
         markdownHandler
-            "https://raw.githubusercontent.com/giraffe-fsharp/Giraffe/main/README.md"
+            "https://raw.githubusercontent.com/giraffe-fsharp/Giraffe/master/README.md"
             "Home"
             (Url.create "/")
             4
@@ -268,7 +268,7 @@ module WebApp =
     let private docsHandler =
         allowCaching (TimeSpan.FromDays(1.0)) >=>
         markdownHandler
-            "https://raw.githubusercontent.com/giraffe-fsharp/Giraffe/main/DOCUMENTATION.md"
+            "https://raw.githubusercontent.com/giraffe-fsharp/Giraffe/master/DOCUMENTATION.md"
             "Documentation"
             (Url.create "/docs")
             0

--- a/src/Giraffe.Website/Program.fs
+++ b/src/Giraffe.Website/Program.fs
@@ -209,7 +209,6 @@ module WebApp =
     open System.Net.Http
     open Microsoft.Extensions.Logging
     open Microsoft.Net.Http.Headers
-    open FSharp.Control.Tasks
     open Giraffe
     open Giraffe.EndpointRouting
     open Giraffe.ViewEngine


### PR DESCRIPTION
> [!WARNING]
> Notice that the branch name is misleading. My bad. I changed the PR direction while working on it.

## Description

With this PR, I'm:

* Updating the project to .NET 8 (F# and Dockerfile).

## Related

- https://github.com/giraffe-fsharp/Giraffe/pull/593

## How to test

* If you're testing this PR before the related PR is merged, please change the Giraffe markdown URLs back to point to the `master` branch.

```bash
dotnet run --project src/Giraffe.Website/
# open the localhost:5000/ and make sure that it's working well (giraffe.wiki)
```

The Docker container:

```bash
docker build --build-arg version="0.0.1" -t "giraffefsharp/giraffe-website:0.0.1" -f src/Giraffe.Website/Dockerfile .

docker container run giraffefsharp/giraffe-website:0.0.1

# notice that we defined the environment variable ASPNETCORE_HTTP_PORTS due to a breaking
# change on .NET 8
docker container run -d -p 5000:5000 -e ASPNETCORE_HTTP_PORTS=5000 giraffefsharp/giraffe-website:0.0.1
```

⚠️ More information about the .NET 8 default port breaking change: [link](https://learn.microsoft.com/en-us/dotnet/core/compatibility/containers/8.0/aspnet-port). This must impact the deployment of a new server version, so we'll need to talk to @dustinmoris.

This Docker image is available at: https://hub.docker.com/r/giraffefsharp/giraffe-website.