### PR TITLE
Minor CSS change

### DIFF
--- a/src/Giraffe.Website/Assets/Private/main.css
+++ b/src/Giraffe.Website/Assets/Private/main.css
@@ -4,6 +4,7 @@ body {
     -ms-word-wrap: break-word;
     word-wrap: break-word;
     font-size: 1.1em;
+    font-variant-ligatures: none;
 }
 
 header, main, nav, footer {


### PR DESCRIPTION
Preventing the `=>` part of the text `>=>` from being rendered as a fat arrow:

<img width="164" alt="toc" src="https://github.com/giraffe-fsharp/giraffe-website/assets/2664441/da2ef798-6040-4802-a156-80a592261def">
<img width="218" alt="title" src="https://github.com/giraffe-fsharp/giraffe-website/assets/2664441/c53f17c2-10e6-4c89-8fd7-0938153ef454">

